### PR TITLE
Set dash cooldown to 1.5s

### DIFF
--- a/tower-defense/index.html
+++ b/tower-defense/index.html
@@ -27,7 +27,7 @@ let dashVelocityX = 0;
 let dashVelocityY = 0;
 const dashSpeed = 20;
 const dashDuration = 15;
-const dashCooldown = 60; // ~1 second at 60 fps
+const dashCooldown = 90; // ~1.5 seconds at 60 fps
 let dashTime = 0;
 let dashCooldownTime = 0;
 


### PR DESCRIPTION
## Summary
- tweak dashCooldown to 90 frames (~1.5 seconds)

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844308cbec0832e93b89a5e57bcc10d