### PR TITLE
Add player health, enemy projectiles and game over

### DIFF
--- a/tower-defense/index.html
+++ b/tower-defense/index.html
@@ -31,6 +31,19 @@ const dashCooldown = 90; // ~1.5 seconds at 60 fps
 let dashTime = 0;
 let dashCooldownTime = 0;
 
+// Lebensanzeige
+const maxHealth = 100;
+let playerHealth = maxHealth;
+let gameOver = false;
+
+// Projektile
+const projectiles = [];
+const projectileSpeed = 6;
+const projectileDamage = 10;
+
+// Gegner Schussintervall
+const enemyShootInterval = 90;
+
 // Gegnerverwaltung
 const enemies = [];
 const enemyRadius = 20;
@@ -47,6 +60,12 @@ const keys = {
 
 function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    // Lebensbalken
+    ctx.fillStyle = 'gray';
+    ctx.fillRect(10, 10, canvas.width - 20, 20);
+    ctx.fillStyle = 'green';
+    ctx.fillRect(10, 10, (playerHealth / maxHealth) * (canvas.width - 20), 20);
+
     // Spieler zeichnen
     ctx.fillStyle = 'blue';
     ctx.beginPath();
@@ -58,6 +77,21 @@ function draw() {
         ctx.beginPath();
         ctx.arc(e.x, e.y, enemyRadius, 0, Math.PI * 2);
         ctx.fill();
+    }
+
+    // Projektile zeichnen
+    ctx.fillStyle = 'darkred';
+    for (const p of projectiles) {
+        ctx.fillRect(p.x - 2, p.y - 2, 4, 4);
+    }
+
+    if (gameOver) {
+        ctx.fillStyle = 'rgba(0,0,0,0.5)';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = 'white';
+        ctx.font = '48px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('Game Over', canvas.width / 2, canvas.height / 2);
     }
 }
 
@@ -82,7 +116,7 @@ function spawnEnemy() {
             y = Math.random() * canvas.height;
             break;
     }
-    enemies.push({x, y});
+    enemies.push({x, y, shootTimer: enemyShootInterval});
 }
 
 // Tastatursteuerung: W = vor, A = links, D = rechts, S = hinten
@@ -124,6 +158,10 @@ document.addEventListener('keyup', (e) => {
 });
 
 function update() {
+    if (gameOver) {
+        draw();
+        return;
+    }
     if (dashCooldownTime > 0) dashCooldownTime--;
     if (--enemySpawnTimer <= 0) {
         spawnEnemy();
@@ -134,6 +172,12 @@ function update() {
         posX += dashVelocityX;
         posY += dashVelocityY;
         dashTime--;
+        for (let i = enemies.length - 1; i >= 0; i--) {
+            const e = enemies[i];
+            if (Math.hypot(e.x - posX, e.y - posY) <= radius + enemyRadius) {
+                enemies.splice(i, 1);
+            }
+        }
     } else {
         let ax = 0;
         let ay = 0;
@@ -164,19 +208,48 @@ function update() {
         posY += velocityY;
     }
 
-    // Gegner bewegen
+    // Gegner bewegen und schießen
     for (const e of enemies) {
         const dx = posX - e.x;
         const dy = posY - e.y;
         const len = Math.hypot(dx, dy) || 1;
         e.x += (dx / len) * enemySpeed;
         e.y += (dy / len) * enemySpeed;
+        if (--e.shootTimer <= 0) {
+            projectiles.push({
+                x: e.x,
+                y: e.y,
+                vx: (dx / len) * projectileSpeed,
+                vy: (dy / len) * projectileSpeed
+            });
+            e.shootTimer = enemyShootInterval;
+        }
+    }
+
+    // Projektile bewegen
+    for (let i = projectiles.length - 1; i >= 0; i--) {
+        const p = projectiles[i];
+        p.x += p.vx;
+        p.y += p.vy;
+        if (p.x < 0 || p.x > canvas.width || p.y < 0 || p.y > canvas.height) {
+            projectiles.splice(i, 1);
+            continue;
+        }
+        if (Math.hypot(p.x - posX, p.y - posY) <= radius) {
+            playerHealth -= projectileDamage;
+            projectiles.splice(i, 1);
+            if (playerHealth <= 0) {
+                gameOver = true;
+            }
+        }
     }
 
     posX = Math.min(Math.max(radius, posX), canvas.width - radius);
     posY = Math.min(Math.max(radius, posY), canvas.height - radius);
     draw();
-    requestAnimationFrame(update);
+    if (!gameOver) {
+        requestAnimationFrame(update);
+    }
 }
 
 draw();


### PR DESCRIPTION
## Summary
- add health values and projectile framework
- draw health bar and game over overlay
- allow dash to destroy enemies and enemies to shoot
- stop the game when player's health reaches zero

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68443320ab9c832ea2fe978e989a943b