### PR TITLE
Add health pack spawning and restart feature

### DIFF
--- a/tower-defense/index.html
+++ b/tower-defense/index.html
@@ -51,6 +51,12 @@ const enemySpeed = 2;
 const enemySpawnInterval = 120;
 let enemySpawnTimer = enemySpawnInterval;
 
+// Heilpakete
+const healthPacks = [];
+const healthPackSize = 20;
+const healthSpawnInterval = 300; // 5 Sekunden bei ~60 fps
+let healthSpawnTimer = healthSpawnInterval;
+
 const keys = {
     w: false,
     a: false,
@@ -79,6 +85,12 @@ function draw() {
         ctx.fill();
     }
 
+    // Heilpakete zeichnen
+    ctx.fillStyle = 'lime';
+    for (const hp of healthPacks) {
+        ctx.fillRect(hp.x, hp.y, healthPackSize, healthPackSize);
+    }
+
     // Projektile zeichnen
     ctx.fillStyle = 'darkred';
     for (const p of projectiles) {
@@ -92,6 +104,8 @@ function draw() {
         ctx.font = '48px sans-serif';
         ctx.textAlign = 'center';
         ctx.fillText('Game Over', canvas.width / 2, canvas.height / 2);
+        ctx.font = '24px sans-serif';
+        ctx.fillText('Enter dr\xFCcken zum Neustart', canvas.width / 2, canvas.height / 2 + 40);
     }
 }
 
@@ -119,10 +133,20 @@ function spawnEnemy() {
     enemies.push({x, y, shootTimer: enemyShootInterval});
 }
 
+function spawnHealth() {
+    const x = Math.random() * (canvas.width - healthPackSize);
+    const y = Math.random() * (canvas.height - healthPackSize);
+    healthPacks.push({x, y});
+}
+
 // Tastatursteuerung: W = vor, A = links, D = rechts, S = hinten
 // Space löst einen kurzen Dash aus
 document.addEventListener('keydown', (e) => {
     const key = e.key.toLowerCase();
+    if (gameOver && key === 'enter') {
+        restartGame();
+        return;
+    }
     if (e.code === 'Space' && dashTime <= 0 && dashCooldownTime <= 0) {
         let dx = 0;
         let dy = 0;
@@ -168,6 +192,11 @@ function update() {
         enemySpawnTimer = enemySpawnInterval;
     }
 
+    if (--healthSpawnTimer <= 0) {
+        spawnHealth();
+        healthSpawnTimer = healthSpawnInterval;
+    }
+
     if (dashTime > 0) {
         posX += dashVelocityX;
         posY += dashVelocityY;
@@ -206,6 +235,16 @@ function update() {
 
         posX += velocityX;
         posY += velocityY;
+    }
+
+    // Heilpaket einsammeln
+    for (let i = healthPacks.length - 1; i >= 0; i--) {
+        const h = healthPacks[i];
+        if (posX + radius > h.x && posX - radius < h.x + healthPackSize &&
+            posY + radius > h.y && posY - radius < h.y + healthPackSize) {
+            playerHealth = Math.min(maxHealth, playerHealth + maxHealth / 4);
+            healthPacks.splice(i, 1);
+        }
     }
 
     // Gegner bewegen und schießen
@@ -250,6 +289,27 @@ function update() {
     if (!gameOver) {
         requestAnimationFrame(update);
     }
+}
+
+function restartGame() {
+    enemies.length = 0;
+    projectiles.length = 0;
+    healthPacks.length = 0;
+    playerHealth = maxHealth;
+    posX = canvas.width / 2;
+    posY = canvas.height / 2;
+    velocityX = 0;
+    velocityY = 0;
+    dashVelocityX = 0;
+    dashVelocityY = 0;
+    dashTime = 0;
+    dashCooldownTime = 0;
+    keys.w = keys.a = keys.s = keys.d = false;
+    enemySpawnTimer = enemySpawnInterval;
+    healthSpawnTimer = healthSpawnInterval;
+    gameOver = false;
+    draw();
+    requestAnimationFrame(update);
 }
 
 draw();


### PR DESCRIPTION
## Summary
- drop green health packs every 5 seconds
- picking a health pack restores a quarter of max health
- allow restarting the game by pressing Enter after death

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684434801e28832e811c4cb07f4d357f