### PR TITLE
Adjust world generation balance

### DIFF
--- a/openworld-sandbox/index.html
+++ b/openworld-sandbox/index.html
@@ -33,8 +33,8 @@ const world = [];
 for (let y = 0; y < worldHeight; y++) {
     world[y] = [];
     for (let x = 0; x < worldWidth; x++) {
-        // etwas mehr Land erzeugen
-        world[y][x] = random() < 0.35 ? 1 : 0;
+        // etwas mehr Land erzeugen (etwas mehr Wasser mit 40% Chance)
+        world[y][x] = random() < 0.40 ? 1 : 0;
     }
 }
 
@@ -104,13 +104,13 @@ function removeSmallRegions(map, type, minSize) {
 removeSmallRegions(world, 0, 3); // kleine Landflecken im Wasser entfernen
 removeSmallRegions(world, 1, 3); // kleine Wasserflecken auf dem Land entfernen
 
-// jedes 10. Bodenfeld in Stein oder Baum umwandeln
+// jedes 15. Bodenfeld in Stein oder Baum umwandeln
 let groundCounter = 0;
 for (let y = 0; y < worldHeight; y++) {
     for (let x = 0; x < worldWidth; x++) {
         if (world[y][x] === 0) {
             groundCounter++;
-            if (groundCounter % 10 === 0) {
+            if (groundCounter % 15 === 0) {
                 world[y][x] = random() < 0.5 ? 2 : 3;
             }
         }


### PR DESCRIPTION
## Summary
- tweak water generation probability
- lower tree/stone spawn rate

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684446083fbc832e8ba0f580f9607462