### PR TITLE
Implement endless terrain and smoother movement

### DIFF
--- a/openworld-sandbox/index.html
+++ b/openworld-sandbox/index.html
@@ -13,115 +13,47 @@
 <script>
 // Tile-Größe und Weltgröße
 const tileSize = 16;
-const worldWidth = 200;
-const worldHeight = 200;
-
-// Lineare Kongruenzgenerator für deterministischen Zufall
-function LCG(seed) {
-    return function() {
-        seed = Math.imul(seed, 1664525) + 1013904223 | 0;
-        return ((seed >>> 0) / 4294967296);
-    };
-}
 
 const seed = Date.now() & 0xffffffff; // neuer Seed bei jedem Start
-const random = LCG(seed);
 
-// Welt-Array erstellen
-// 0 = Boden, 1 = Wasser, 2 = Stein, 3 = Baum
-const world = [];
-for (let y = 0; y < worldHeight; y++) {
-    world[y] = [];
-    for (let x = 0; x < worldWidth; x++) {
-        // etwas mehr Land erzeugen
-        world[y][x] = random() < 0.35 ? 1 : 0;
-        // etwas mehr Land erzeugen (etwas mehr Wasser mit 40% Chance)
-        world[y][x] = random() < 0.40 ? 1 : 0;
-    }
+// deterministisches Rauschen für zufällige, aber reproduzierbare Tiles
+function noise(x, y) {
+    const n = Math.sin(x * 12.9898 + y * 78.233 + seed) * 43758.5453;
+    return n - Math.floor(n);
 }
 
-// Smoothing, damit zusammenhängendes Land/Wasser entsteht
-function smooth(map) {
-    const copy = [];
-    for (let y = 0; y < worldHeight; y++) {
-        copy[y] = map[y].slice();
-    }
-    for (let y = 0; y < worldHeight; y++) {
-        for (let x = 0; x < worldWidth; x++) {
-            let waterCount = 0;
-            for (let dy = -1; dy <= 1; dy++) {
-                for (let dx = -1; dx <= 1; dx++) {
-                    if (dx === 0 && dy === 0) continue;
-                    const nx = x + dx;
-                    const ny = y + dy;
-                    if (nx < 0 || ny < 0 || nx >= worldWidth || ny >= worldHeight) {
-                        waterCount++;
-                    } else if (map[ny][nx] === 1) {
-                        waterCount++;
-                    }
-                }
-            }
-            copy[y][x] = waterCount > 4 ? 1 : waterCount < 4 ? 0 : copy[y][x];
-        }
-    }
-    return copy;
+// Welt-Map nur für die besuchten Tiles speichern
+const world = new Map();
+
+function tileKey(x, y) {
+    return `${x},${y}`;
 }
 
-// Die Karte zwei Mal glätten
-let temp = smooth(world);
-world.splice(0, world.length, ...smooth(temp));
+function generateTile(x, y) {
+    const r = noise(x / 20, y / 20);
+    if (r < 0.4) return 1; // Wasser
 
-// Kleine Regionen entfernen
-function removeSmallRegions(map, type, minSize) {
-    const visited = [];
-    for (let y = 0; y < worldHeight; y++) {
-        visited[y] = [];
-        for (let x = 0; x < worldWidth; x++) {
-            visited[y][x] = false;
-        }
-    }
-
-    for (let y = 0; y < worldHeight; y++) {
-        for (let x = 0; x < worldWidth; x++) {
-            if (visited[y][x] || map[y][x] !== type) continue;
-            const stack = [[x, y]];
-            const region = [];
-            visited[y][x] = true;
-            while (stack.length > 0) {
-                const [cx, cy] = stack.pop();
-                region.push([cx, cy]);
-                const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
-                for (const [dx, dy] of dirs) {
-                    const nx = cx + dx;
-                    const ny = cy + dy;
-                    if (nx < 0 || ny < 0 || nx >= worldWidth || ny >= worldHeight) continue;
-                    if (!visited[ny][nx] && map[ny][nx] === type) {
-                        visited[ny][nx] = true;
-                        stack.push([nx, ny]);
-                    }
-                }
-            }
-            if (region.length <= minSize) {
-                for (const [rx, ry] of region) {
-                    map[ry][rx] = 1 - type;
-                }
-            }
-        }
-    }
+    // Boden mit gelegentlichen Steinen oder Bäumen
+    const r2 = noise(x * 2, y * 2);
+    if (r2 > 0.97) return 2; // Stein
+    if (r2 > 0.94) return 3; // Baum
+    return 0; // normaler Boden
 }
 
-removeSmallRegions(world, 0, 3); // kleine Landflecken im Wasser entfernen
-removeSmallRegions(world, 1, 3); // kleine Wasserflecken auf dem Land entfernen
+function getTile(x, y) {
+    const key = tileKey(x, y);
+    if (world.has(key)) return world.get(key);
+    const tile = generateTile(x, y);
+    world.set(key, tile);
+    return tile;
+}
 
-// jedes 15. Bodenfeld in Stein oder Baum umwandeln
-let groundCounter = 0;
-for (let y = 0; y < worldHeight; y++) {
-    for (let x = 0; x < worldWidth; x++) {
-        if (world[y][x] === 0) {
-            groundCounter++;
-            if (groundCounter % 15 === 0) {
-                world[y][x] = random() < 0.5 ? 2 : 3;
-            }
+// veraltete Tiles entfernen, um Speicher zu sparen
+function cleanup(cx, cy) {
+    for (const key of world.keys()) {
+        const [x, y] = key.split(',').map(Number);
+        if (Math.abs(x - cx) > 100 || Math.abs(y - cy) > 100) {
+            world.delete(key);
         }
     }
 }
@@ -129,18 +61,19 @@ for (let y = 0; y < worldHeight; y++) {
 const canvas = document.getElementById('game');
 const ctx = canvas.getContext('2d');
 
-let cameraX = worldWidth / 2 - canvas.width / tileSize / 2;
-let cameraY = worldHeight / 2 - canvas.height / tileSize / 2;
+let cameraX = 0;
+let cameraY = 0;
 
-// Kamerasteuerung mit Pfeiltasten oder WASD
-const speed = 4 / tileSize;
+// gedrückte Tasten speichern
+const keys = {};
 document.addEventListener('keydown', (e) => {
-    const key = e.key.toLowerCase();
-    if (key === 'arrowup' || key === 'w') cameraY -= speed;
-    if (key === 'arrowdown' || key === 's') cameraY += speed;
-    if (key === 'arrowleft' || key === 'a') cameraX -= speed;
-    if (key === 'arrowright' || key === 'd') cameraX += speed;
+    keys[e.key.toLowerCase()] = true;
 });
+document.addEventListener('keyup', (e) => {
+    keys[e.key.toLowerCase()] = false;
+});
+
+const speed = 6 / tileSize; // etwas schnelleres Bewegen
 
 function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -153,8 +86,7 @@ function draw() {
         for (let x = 0; x <= tilesX; x++) {
             const mapX = startX + x;
             const mapY = startY + y;
-            if (mapX < 0 || mapY < 0 || mapX >= worldWidth || mapY >= worldHeight) continue;
-            const tile = world[mapY][mapX];
+            const tile = getTile(mapX, mapY);
             if (tile === 1) ctx.fillStyle = '#99ddee';
             else if (tile === 2) ctx.fillStyle = '#888';
             else if (tile === 3) ctx.fillStyle = '#8B4513';
@@ -162,10 +94,20 @@ function draw() {
             ctx.fillRect((mapX - cameraX) * tileSize, (mapY - cameraY) * tileSize, tileSize, tileSize);
         }
     }
-    requestAnimationFrame(draw);
+    cleanup(startX + tilesX / 2, startY + tilesY / 2);
 }
 
-draw();
+function update() {
+    if (keys['arrowup'] || keys['w']) cameraY -= speed;
+    if (keys['arrowdown'] || keys['s']) cameraY += speed;
+    if (keys['arrowleft'] || keys['a']) cameraX -= speed;
+    if (keys['arrowright'] || keys['d']) cameraX += speed;
+
+    draw();
+    requestAnimationFrame(update);
+}
+
+requestAnimationFrame(update);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- generate tiles on demand instead of using a fixed world map
- cache visited tiles and clean up far away ones
- add continuous WASD/arrow key controls and increase camera speed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684451fec930832ea1bfa26ab1d21db5