### PR TITLE
Update terrain generation logic

### DIFF
--- a/openworld-sandbox/index.html
+++ b/openworld-sandbox/index.html
@@ -29,16 +29,34 @@ function tileKey(x, y) {
     return `${x},${y}`;
 }
 
-function generateTile(x, y) {
-    // geringere Frequenz für größere Wasser-/Land-Flecken
-    const r = noise(x / 50, y / 50);
-    if (r < 0.4) return 1; // Wasser
+// Basistyp (0 = Land, 1 = Wasser) ohne weitere Objekte
+function baseTerrain(x, y) {
+    // noch geringere Frequenz für zusammenhängendere Flächen
+    const r = noise(x / 70, y / 70);
+    return r < 0.4 ? 1 : 0;
+}
 
-    // Boden mit gelegentlichen Steinen oder Bäumen
-    const r2 = noise(x * 2, y * 2);
-    if (r2 > 0.97) return 2; // Stein
-    if (r2 > 0.94) return 3; // Baum
-    return 0; // normaler Boden
+function generateTile(x, y) {
+    let type = baseTerrain(x, y);
+
+    // kleine Inseln/globules entfernen
+    let waterNeighbors = 0;
+    for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+            if (dx === 0 && dy === 0) continue;
+            if (baseTerrain(x + dx, y + dy) === 1) waterNeighbors++;
+        }
+    }
+    if (type === 1 && waterNeighbors <= 3) type = 0;
+    if (type === 0 && waterNeighbors >= 5) type = 1;
+
+    // Boden mit 1/17 Chance auf Stein oder Baum
+    if (type === 0) {
+        const r2 = noise(x * 2, y * 2);
+        if (r2 < 1 / 34) return 2; // Stein
+        if (r2 < 2 / 34) return 3; // Baum
+    }
+    return type;
 }
 
 function getTile(x, y) {


### PR DESCRIPTION
## Summary
- refine terrain generation in openworld sandbox
- add baseTerrain function for more contiguous areas
- convert tiny opposite-terrain patches
- apply 1/17 chance for trees or stones on land tiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68445694aa00832ea56411673130441d