### PR TITLE
Add collision detection for player

### DIFF
--- a/openworld-sandbox/index.html
+++ b/openworld-sandbox/index.html
@@ -16,6 +16,11 @@ let tileSize = 16;
 const baseSpeed = 6;
 let speed = baseSpeed / tileSize;
 
+// Tiles auf denen der Spieler laufen darf (0 = Land, 4 = Rathaus)
+function walkable(tile) {
+    return tile === 0 || tile === 4;
+}
+
 let player = null; // erscheint nach dem Platzieren des Rathauses
 
 const seed = Date.now() & 0xffffffff; // neuer Seed bei jedem Start
@@ -70,6 +75,10 @@ function getTile(x, y) {
     const tile = generateTile(x, y);
     world.set(key, tile);
     return tile;
+}
+
+function isWalkableAt(x, y) {
+    return walkable(getTile(Math.floor(x), Math.floor(y)));
 }
 
 // veraltete Tiles entfernen, um Speicher zu sparen
@@ -183,10 +192,21 @@ function draw() {
 
 function update() {
     if (player) {
-        if (keys['w']) player.y -= speed;
-        if (keys['s']) player.y += speed;
-        if (keys['a']) player.x -= speed;
-        if (keys['d']) player.x += speed;
+        let newX = player.x;
+        let newY = player.y;
+        if (keys['w']) newY -= speed;
+        if (keys['s']) newY += speed;
+        if (keys['a']) newX -= speed;
+        if (keys['d']) newX += speed;
+
+        if (isWalkableAt(newX, newY)) {
+            player.x = newX;
+            player.y = newY;
+        } else {
+            if (isWalkableAt(newX, player.y)) player.x = newX;
+            if (isWalkableAt(player.x, newY)) player.y = newY;
+        }
+
         cameraX = player.x - canvas.width / tileSize / 2;
         cameraY = player.y - canvas.height / tileSize / 2;
     } else {


### PR DESCRIPTION
## Summary
- keep existing sandbox functionality
- add `walkable` helper and `isWalkableAt` to classify map tiles
- prevent the player from entering water, trees or stones after the town hall was placed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844626842e8832ea89d2558fa8277f8