### PR TITLE
Add resource harvesting and town hall indicator

### DIFF
--- a/openworld-sandbox/index.html
+++ b/openworld-sandbox/index.html
@@ -14,6 +14,7 @@
 // Tile-Größe und Weltgröße
 let tileSize = 16;
 const baseSpeed = 6;
+const playerSpeed = 10; // Felder pro Sekunde im Player-Modus
 let speed = baseSpeed / tileSize;
 
 // Tiles auf denen der Spieler laufen darf (0 = Land, 4 = Rathaus)
@@ -103,6 +104,7 @@ let hoveredTile = null;
 const clickedTiles = new Set();
 // nur ein gelb markiertes Feld (Rathaus) zulassen
 let townHallPlaced = false;
+let townHallPos = null; // Position des Rathauses
 
 let mouseX = 0;
 let mouseY = 0;
@@ -132,21 +134,59 @@ canvas.addEventListener('mouseleave', () => {
 
 // Bodenfeld beim ersten Klick gelb markieren
 canvas.addEventListener('mousedown', () => {
-    if (!hoveredTile || townHallPlaced) return;
+    if (!hoveredTile) return;
     const { x, y } = hoveredTile;
     const key = tileKey(x, y);
-    if (!clickedTiles.has(key) && getTile(x, y) === 0) {
-        clickedTiles.add(key);
-        world.set(key, 4); // State zu Rathaus 
-        townHallPlaced = true;
-        // Spieler erzeugen und Kamera zentrieren
-        player = { x: x + 0.5, y: y + 0.5 };
-        tileSize = 24; // leichtes Reinzoomen
-        speed = baseSpeed / tileSize;
-        cameraX = player.x - canvas.width / tileSize / 2;
-        cameraY = player.y - canvas.height / tileSize / 2;
+
+    if (!townHallPlaced) {
+        if (!clickedTiles.has(key) && getTile(x, y) === 0) {
+            clickedTiles.add(key);
+            world.set(key, 4); // State zu Rathaus
+            townHallPlaced = true;
+            townHallPos = { x, y };
+            // Spieler erzeugen und Kamera zentrieren
+            player = { x: x + 0.5, y: y + 0.5 };
+            tileSize = 24; // leichtes Reinzoomen
+            speed = playerSpeed / tileSize;
+            cameraX = player.x - canvas.width / tileSize / 2;
+            cameraY = player.y - canvas.height / tileSize / 2;
+        }
+    } else {
+        const tile = getTile(x, y);
+        if ((tile === 2 || tile === 3) &&
+            Math.abs(x + 0.5 - player.x) <= 1 &&
+            Math.abs(y + 0.5 - player.y) <= 1) {
+            world.set(key, 0); // Resource abbauen
+        }
     }
 });
+
+function drawTownHallIndicator() {
+    if (!townHallPos) return;
+    const sx = (townHallPos.x + 0.5 - cameraX) * tileSize;
+    const sy = (townHallPos.y + 0.5 - cameraY) * tileSize;
+    if (sx >= 0 && sx <= canvas.width && sy >= 0 && sy <= canvas.height) return;
+    const cx = canvas.width / 2;
+    const cy = canvas.height / 2;
+    const dx = sx - cx;
+    const dy = sy - cy;
+    const margin = 20;
+    const scale = Math.max(Math.abs(dx) / (canvas.width / 2 - margin), Math.abs(dy) / (canvas.height / 2 - margin));
+    const ax = cx + dx / scale;
+    const ay = cy + dy / scale;
+    const angle = Math.atan2(dy, dx);
+    ctx.save();
+    ctx.translate(ax, ay);
+    ctx.rotate(angle);
+    ctx.fillStyle = 'yellow';
+    ctx.beginPath();
+    ctx.moveTo(0, -10);
+    ctx.lineTo(6, 10);
+    ctx.lineTo(-6, 10);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+}
 
 
 function draw() {
@@ -187,6 +227,7 @@ function draw() {
         ctx.lineWidth = pulse;
         ctx.strokeRect(sx, sy, tileSize, tileSize);
     }
+    drawTownHallIndicator();
     cleanup(startX + tilesX / 2, startY + tilesY / 2);
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated player speed of 10 tiles per second
- store the placed town hall position
- allow harvesting tree/stone resources when adjacent
- show an on-screen arrow pointing to the town hall if it is off-screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6844664b914c832e9cfac320f6db9fbc