### PR TITLE
Fix inventory to hotbar drag restrictions

### DIFF
--- a/openworld-sandbox/index.html
+++ b/openworld-sandbox/index.html
@@ -475,6 +475,9 @@ function renderHotbar() {
                 icon.style.color = '#ccc';
             }
             cell.appendChild(icon);
+            cell.draggable = true;
+        } else {
+            cell.draggable = false;
         }
         cell.classList.toggle('selected', i === hotbarSelected);
     }
@@ -504,11 +507,15 @@ hotbarDiv.addEventListener('drop', (e) => {
         const sourceIndex = parseInt(src.slice(1), 10);
         const item = inventory[sourceIndex];
         if (!item) return;
+        // only allow tools in the hotbar
+        if (item.type !== 'stonePickaxe' && item.type !== 'stoneAxe') return;
         const cell = e.target.closest('.hotbar-cell');
         if (!cell) return;
         const targetIndex = Array.prototype.indexOf.call(hotbarDiv.children, cell);
+        // prevent overwriting existing items
+        if (hotbar[targetIndex]) return;
         hotbar[targetIndex] = { type: item.type };
-        inventory[sourceIndex] = null;
+        if (item.count > 1) item.count -= 1; else inventory[sourceIndex] = null;
         renderInventory();
         renderHotbar();
     }


### PR DESCRIPTION
## Summary
- make hotbar cells draggable only if they contain an item
- restrict hotbar drops to tools (stone pickaxe or stone axe)
- prevent overwriting hotbar items and decrement count in inventory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845a49eafd4832e9e2b4cb6b28e8f1d